### PR TITLE
Use ansible-galaxy rather than GitHub

### DIFF
--- a/digitalocean/requirements.yml
+++ b/digitalocean/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: https://github.com/elastic/ansible-beats
+- src: elastic.beats
 
 - src: AnsibleShipyard.ansible-zookeeper
   version: 0.23.0

--- a/packet_net/requirements.yml
+++ b/packet_net/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: https://github.com/elastic/ansible-beats
+- src: elastic.beats
 
 - src: entercloudsuite.haproxy
 


### PR DESCRIPTION
It looks like Elastic started publishing their `ansible-beats` role on Ansible Galaxy:

https://galaxy.ansible.com/elastic/beats

@mwl Thoughts on switching to this over pulling `master` every time?