### PR TITLE
Remove beats & move ansible user location

### DIFF
--- a/bare_metal/ansible.cfg
+++ b/bare_metal/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
 inventory = inventory.ini
-remote_user = root
 host_key_checking = false
 
 [ssh_connection]

--- a/bare_metal/inventory.ini
+++ b/bare_metal/inventory.ini
@@ -26,6 +26,7 @@ humio3 ansible_host=10.0.0.13 cluster_index=3
 # used to connect to the host machines that are configured by ansible.
 [humios:vars]
 ansible_port=22
+ansible_user=root
 ansible_ssh_private_key_file=/path/to/ssh_private_key_file
 
 ############################################

--- a/bare_metal/inventory.ini
+++ b/bare_metal/inventory.ini
@@ -16,18 +16,12 @@ humio3 ansible_host=10.0.0.13 cluster_index=3
 #
 # These variables are applied to each host.
 #
-# `ansible_port`: By default, the ansible SSH port being used is
-# set to `22`. If all hosts share the same port, then you can update
-# it here if something other than `22` is used. If each host has a
-# separate port number, then you can move it to the above section
-# and specify it on a per-host basis.
-#
-# `ansible_ssh_private_key_file`: The path to the private key that's
-# used to connect to the host machines that are configured by ansible.
 [humios:vars]
-# This is the default port for SSH. If you're using a different port
-# you can specify that here. If each machine has a different port,
-# you can add an `ansible_port=...` entry to each hose above.
+# By default, the ansible SSH port being used is the default SSH port
+# (`22`). If all hosts share the same port, then you can update
+# it here to something other than `22`. If each host has a
+# unique port number, then you can move it to the above section
+# and specify it on a per-host basis.
 ansible_port=22
 
 # Change this to whatever remote user will be executing the commands

--- a/bare_metal/inventory.ini
+++ b/bare_metal/inventory.ini
@@ -25,8 +25,21 @@ humio3 ansible_host=10.0.0.13 cluster_index=3
 # `ansible_ssh_private_key_file`: The path to the private key that's
 # used to connect to the host machines that are configured by ansible.
 [humios:vars]
+# This is the default port for SSH. If you're using a different port
+# you can specify that here. If each machine has a different port,
+# you can add an `ansible_port=...` entry to each hose above.
 ansible_port=22
+
+# Change this to whatever remote user will be executing the commands
+# on the servers you're installing to. It will need passwordless sudo
+# permissions or you will be prompted repeatedly for a password
+# every time you run the playbook.
 ansible_user=root
+
+# This is the path to the private key file on your local machine that
+# will be used to connect to the remote systems. This key should be
+# added to the ~/.ssh/authorized_keys file on all of the remote machines
+# under the user account specified above.
 ansible_ssh_private_key_file=/path/to/ssh_private_key_file
 
 ############################################

--- a/bare_metal/requirements.yml
+++ b/bare_metal/requirements.yml
@@ -1,8 +1,4 @@
 ---
-- src: https://github.com/elastic/ansible-beats
-
-- src: entercloudsuite.haproxy
-
 - src: AnsibleShipyard.ansible-zookeeper
   version: 0.23.0
 

--- a/bare_metal/site.yml
+++ b/bare_metal/site.yml
@@ -1,36 +1,6 @@
 ---
 ############################################
 #
-# Install Metricbeat on all hosts
-#
-- hosts: all
-  tags: always
-  roles:
-  - role: ansible-beats
-    become: true
-    beat: "metricbeat"
-    beat_conf:
-      "metricbeat.modules":
-      - "module": "system"
-        "metricsets":
-          - "cpu"
-          - "load"
-          - "core"
-          - "diskio"
-          - "filesystem"
-          - "fsstat"
-          - "memory"
-          - "network"
-          - "process"
-          - "socket"
-        "enabled": true
-        "period": "10s"
-        "processes": [".*"]
-        "cpu_ticks": false
-
-
-############################################
-#
 # Install Java + Zookeeper roles on zookeeper hosts
 #
 - hosts: zookeepers
@@ -69,50 +39,13 @@
 
 ############################################
 #
-# Install Filebeat + HAProxy + Java + Humio roles on humio hosts
+# Install Java + Humio roles on humio hosts
 #
 - hosts: humios
   tags: humio
   serial: 1
   become: true
   roles:
-    - role: ansible-beats
-      beat: "filebeat"
-      beat_conf:
-        "filebeat":
-          "inputs":
-            - paths:
-              - /var/log/syslog
-              - /var/log/auth.log
-              fields:
-                "@type": syslog-utc
-                "@tags": ["@host", "@type"]
-            - paths:
-              - /var/log/humio/*/humio-debug.log
-              fields:
-                "@type": humio
-                "@tags": ["@host", "@type"]
-              multiline:
-                pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
-                negate: true
-                match: after
-            - paths:
-              - /var/log/kafka/server.log
-              fields:
-                "@type": kafka
-                "@tags": ["@host", "@type"]
-              multiline:
-                pattern: '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}'
-                negate: true
-                match: after
-    - role: entercloudsuite.haproxy
-      haproxy_conf: |
-        listen web
-          mode http
-          bind *:80
-          server humio-0 127.0.0.1:8080 maxconn 64
-          server humio-1 127.0.0.1:8081 maxconn 64
-
     - role: humio.java
     - role: humio.server
       zookeeper_hosts: "


### PR DESCRIPTION
This removes metricbeats and filebeats from the playbook. The official roles for these don't support the OSS version, so we either have to use a very old version or run into problems. To avoid issues in the demo, I'm just removing this entirely. If we want, we can revisit adding this back in later if we like.

I'm also removing the `remote_user` definition in `ansible.cfg` and instead relying on the `ansible_user` definition in `inventory.ini`. This reduces the number of files that need to be touched and should simplify things somewhat.