### PR TITLE
Remove unused beats variables

### DIFF
--- a/bare_metal/group_vars/all.yml
+++ b/bare_metal/group_vars/all.yml
@@ -33,13 +33,3 @@ humio_network_interface: enp0s3
 #
 kafka_version: 2.1.1
 kafka_scala_version: 2.12
-
-############################################
-#
-# ansible-beats variables
-#
-beats_version: 7.1.1
-output_conf:
-  "elasticsearch":
-    "hosts": ["{{ lookup('env', 'HUMIO_PARENT_URL') }}"]
-    "username": "{{ lookup('env', 'HUMIO_PARENT_INGEST_TOKEN') }}"


### PR DESCRIPTION
We removed the beats installs from the bare_metal demo in #20, but I missed removing the variables associated with it.