### PR TITLE
Always gather facts from all nodes

### DIFF
--- a/bare_metal/site.yml
+++ b/bare_metal/site.yml
@@ -1,6 +1,27 @@
 ---
 ############################################
 #
+# Gather facts from all machines in the cluster
+#
+# This is required even if you're just running against one specific
+# machine in the cluster because the configuration files need host
+# information for all nodes in the cluster when writing the config
+# files for various services Humio uses.
+#
+- hosts: all
+  become: true
+  serial: 10
+  pre_tasks:
+    - name: Gather facts from ALL hosts (regardless of limit or tags)
+      tags: always
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      when: hostvars[item]['ansible_' + humio_network_interface] is not defined
+      with_items: "{{ groups['all'] }}"
+
+############################################
+#
 # Install Java + Zookeeper roles on zookeeper hosts
 #
 - hosts: zookeepers


### PR DESCRIPTION
This got removed when beats were removed in #20, but is required if you ever perform an ansible run against a single host when you're running a cluster of more than one.