### PR TITLE
Update to latest Zookeeper 3.5.x

### DIFF
--- a/bare_metal/group_vars/all.yml
+++ b/bare_metal/group_vars/all.yml
@@ -3,7 +3,7 @@
 #
 # humio.zookeeper variables
 #
-zookeeper_version: 3.5.7
+zookeeper_version: 3.5.8
 
 ############################################
 #


### PR DESCRIPTION
3.5.8 fixes several leader election related issues. There is no reason for us to not use the latest 3.5.x. version as far as I know.